### PR TITLE
chore: update deprecation notice, add lint/bench targets

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+version: "2"
+linters:
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - funlen
+          - goconst
+          - errcheck
+          - ineffassign
+          - staticcheck
+        path: (.+)_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ doc:
 	gomarkdoc ./...
 
 lint:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	golangci-lint run
 
 bench:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	go build ./...
 
 test:
-	go test ./... -race
+	go test -race ./...
 
 doc:
 	go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
@@ -14,4 +14,4 @@ lint:
 	golangci-lint run
 
 bench:
-	go test -bench=. -benchmem ./...
+	go test -run=^$ -bench=. -benchmem ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test doc
+.PHONY: build test doc lint bench
 
 build:
 	go build ./...
@@ -9,3 +9,9 @@ test:
 doc:
 	go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
 	gomarkdoc ./...
+
+lint:
+	golangci-lint run
+
+bench:
+	go test -bench=. -benchmem ./...

--- a/doc.go
+++ b/doc.go
@@ -7,7 +7,7 @@
 //		promC := hystrixprometheus.NewPrometheusCollector("hystrix", nil, prometheus.DefBuckets)
 //		metricCollector.Registry.Register(promC.Collector)
 //
-// Deprecated: This package wraps the unmaintained github.com/afex/hystrix-go library.
-// No maintained alternative with the same metricCollector.MetricCollector interface exists.
-// Consider migrating to alternative circuit breaker libraries with native Prometheus support.
+// Deprecated: This package wraps the unmaintained github.com/afex/hystrix-go library (last updated 2018).
+// Consider migrating to github.com/failsafe-go/failsafe-go which provides circuit breaker
+// functionality with native Prometheus support.
 package hystrixprometheus


### PR DESCRIPTION
## Summary
- Update deprecation notice to recommend `failsafe-go`
- Add golangci-lint config and `lint`/`bench` Makefile targets

## Test plan
- [x] `make build` passes
- [x] `make test` passes (with -race)
- [x] `make lint` passes with 0 issues